### PR TITLE
feat: add React dashboard with auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dashboard-app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,67 @@
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import NavBar from './components/NavBar.jsx';
+import Login from './pages/Login.jsx';
+import Dashboard from './pages/Dashboard.jsx';
+import Customers from './pages/Customers.jsx';
+import Tasks from './pages/Tasks.jsx';
+import Invoices from './pages/Invoices.jsx';
+import Documents from './pages/Documents.jsx';
+import { AuthProvider, useAuth } from './context/AuthContext.jsx';
+
+function PrivateRoute({ children }) {
+  const { token } = useAuth();
+  return token ? children : <Navigate to="/login" />;
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <Router>
+        <NavBar />
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route
+            path="/"
+            element={
+              <PrivateRoute>
+                <Dashboard />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/customers"
+            element={
+              <PrivateRoute>
+                <Customers />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/tasks"
+            element={
+              <PrivateRoute>
+                <Tasks />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/invoices"
+            element={
+              <PrivateRoute>
+                <Invoices />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/documents"
+            element={
+              <PrivateRoute>
+                <Documents />
+              </PrivateRoute>
+            }
+          />
+        </Routes>
+      </Router>
+    </AuthProvider>
+  );
+}

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'https://api.example.com'
+});
+
+export default api;

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function NavBar() {
+  const { token, logout } = useAuth();
+  if (!token) return null;
+  return (
+    <nav>
+      <Link to="/">Dashboard</Link> |
+      <Link to="/customers">Customers</Link> |
+      <Link to="/tasks">Tasks</Link> |
+      <Link to="/invoices">Invoices</Link> |
+      <Link to="/documents">Documents</Link> |
+      <button onClick={logout}>Logout</button>
+    </nav>
+  );
+}

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState } from 'react';
+import api from '../api/client.js';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+
+  const login = async (email, password) => {
+    const res = await api.post('/auth/login', { email, password });
+    setToken(res.data.token);
+    localStorage.setItem('token', res.data.token);
+  };
+
+  const logout = () => {
+    setToken(null);
+    localStorage.removeItem('token');
+  };
+
+  api.interceptors.request.use(config => {
+    if (token) config.headers.Authorization = `Bearer ${token}`;
+    return config;
+  });
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/Customers.jsx
+++ b/src/pages/Customers.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import api from '../api/client.js';
+
+export default function Customers() {
+  const [customers, setCustomers] = useState([]);
+
+  useEffect(() => {
+    api.get('/customers').then(res => setCustomers(res.data)).catch(() => setCustomers([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Customers</h2>
+      <ul>
+        {customers.map(c => (
+          <li key={c.id}>{c.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <h2>Welcome to the dashboard</h2>;
+}

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import api from '../api/client.js';
+
+export default function Documents() {
+  const [documents, setDocuments] = useState([]);
+
+  useEffect(() => {
+    api.get('/documents').then(res => setDocuments(res.data)).catch(() => setDocuments([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Documents</h2>
+      <ul>
+        {documents.map(d => (
+          <li key={d.id}>{d.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Invoices.jsx
+++ b/src/pages/Invoices.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import api from '../api/client.js';
+
+export default function Invoices() {
+  const [invoices, setInvoices] = useState([]);
+
+  useEffect(() => {
+    api.get('/invoices').then(res => setInvoices(res.data)).catch(() => setInvoices([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Invoices</h2>
+      <ul>
+        {invoices.map(i => (
+          <li key={i.id}>{i.number}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { login } = useAuth();
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    login(email, password);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+      <input value={password} type="password" onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import api from '../api/client.js';
+
+export default function Tasks() {
+  const [tasks, setTasks] = useState([]);
+
+  useEffect(() => {
+    api.get('/tasks').then(res => setTasks(res.data)).catch(() => setTasks([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Tasks</h2>
+      <ul>
+        {tasks.map(t => (
+          <li key={t.id}>{t.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold React dashboard with navigation for customers, tasks, invoices and documents
- add authentication context with token storage and logout
- wire up API client to call REST endpoints

## Testing
- `npm install` *(fails: 403 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a130dafc832f9aa579f471ad29c5