### PR TITLE
Add document management service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+documents.db
+storage/
+test.db
+storage_test/
+.env

--- a/README.md
+++ b/README.md
@@ -8,3 +8,16 @@
 Chrismatthew244/Chrismatthew244 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## Document Service
+
+This repository contains a simple FastAPI application that allows authorized users to upload, preview and delete documents. Files are stored on the local filesystem by default and can optionally be stored on Amazon S3.
+
+### Running locally
+
+```
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+Set the `API_KEY` environment variable and include it in requests using the `X-API-Key` header. The service also respects `DATABASE_URL`, `STORAGE_DIR` and `S3_BUCKET` environment variables for custom configuration.

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,19 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./documents.db")
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,9 @@
+import os
+from fastapi import Header, HTTPException
+
+API_KEY = os.getenv("API_KEY", "secret")
+
+
+def require_api_key(x_api_key: str = Header(...)):
+    if x_api_key != API_KEY:
+        raise HTTPException(status_code=403, detail="Unauthorized")

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,70 @@
+from fastapi import Depends, FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session
+
+from . import models, schemas, storage
+from .database import Base, engine, get_db
+from .dependencies import require_api_key
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+app.mount("/files", StaticFiles(directory=storage.STORAGE_DIR), name="files")
+
+
+@app.post("/documents/", response_model=schemas.DocumentOut, dependencies=[Depends(require_api_key)])
+async def upload_document(
+    customer: str = Form(...),
+    task: str = Form(...),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    path = storage.save_file(file)
+    doc = models.Document(filename=file.filename, path=path, customer=customer, task=task)
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    return schemas.DocumentOut(
+        id=doc.id,
+        filename=doc.filename,
+        url=storage.get_file_url(doc.path),
+        customer=doc.customer,
+        task=doc.task,
+    )
+
+
+@app.get("/documents/{doc_id}", response_model=schemas.DocumentOut, dependencies=[Depends(require_api_key)])
+def read_document(doc_id: int, db: Session = Depends(get_db)):
+    doc = db.query(models.Document).get(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return schemas.DocumentOut(
+        id=doc.id,
+        filename=doc.filename,
+        url=storage.get_file_url(doc.path),
+        customer=doc.customer,
+        task=doc.task,
+    )
+
+
+@app.delete("/documents/{doc_id}", dependencies=[Depends(require_api_key)])
+def delete_document(doc_id: int, db: Session = Depends(get_db)):
+    doc = db.query(models.Document).get(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    storage.delete_file(doc.path)
+    db.delete(doc)
+    db.commit()
+    return {"ok": True}
+
+
+@app.get("/documents/{doc_id}/preview", dependencies=[Depends(require_api_key)])
+def preview_document(doc_id: int, db: Session = Depends(get_db)):
+    doc = db.query(models.Document).get(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    path = doc.path
+    if path.endswith((".txt", ".md")):
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            return {"preview": f.read(200)}
+    return {"detail": "Preview not available"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String
+
+from .database import Base
+
+
+class Document(Base):
+    __tablename__ = "documents"
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, index=True)
+    path = Column(String, unique=True, index=True)
+    customer = Column(String, index=True)
+    task = Column(String, index=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class DocumentBase(BaseModel):
+    customer: str
+    task: str
+
+
+class DocumentCreate(DocumentBase):
+    pass
+
+
+class DocumentOut(DocumentBase):
+    id: int
+    filename: str
+    url: str
+
+    class Config:
+        orm_mode = True

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+from pathlib import Path
+
+import boto3
+from fastapi import UploadFile
+
+STORAGE_DIR = Path(os.getenv("STORAGE_DIR", "storage"))
+S3_BUCKET = os.getenv("S3_BUCKET")
+
+STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def save_file(upload: UploadFile) -> str:
+    """Save an uploaded file. Returns the storage path or S3 URI."""
+    if S3_BUCKET:
+        client = boto3.client("s3")
+        client.upload_fileobj(upload.file, S3_BUCKET, upload.filename)
+        return f"s3://{S3_BUCKET}/{upload.filename}"
+    else:
+        destination = STORAGE_DIR / upload.filename
+        with open(destination, "wb") as buffer:
+            shutil.copyfileobj(upload.file, buffer)
+        return str(destination)
+
+
+def delete_file(path: str) -> None:
+    if path.startswith("s3://"):
+        client = boto3.client("s3")
+        bucket, key = path.replace("s3://", "").split("/", 1)
+        client.delete_object(Bucket=bucket, Key=key)
+    else:
+        try:
+            Path(path).unlink()
+        except FileNotFoundError:
+            pass
+
+
+def get_file_url(path: str) -> str:
+    if path.startswith("s3://"):
+        bucket, key = path.replace("s3://", "").split("/", 1)
+        return f"https://{bucket}.s3.amazonaws.com/{key}"
+    else:
+        return "/files/" + Path(path).name

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+python-multipart
+boto3
+pytest

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,41 @@
+import os
+import shutil
+import tempfile
+
+from fastapi.testclient import TestClient
+
+
+def setup_app():
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "test.db")
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    os.environ["STORAGE_DIR"] = tmpdir
+    os.environ["API_KEY"] = "testkey"
+    from app.main import app
+    return app, tmpdir
+
+
+def test_upload_and_manage_document():
+    app, tmpdir = setup_app()
+    client = TestClient(app)
+    file_content = b"hello world"
+    response = client.post(
+        "/documents/",
+        headers={"X-API-Key": "testkey"},
+        files={"file": ("test.txt", file_content)},
+        data={"customer": "cust", "task": "task"},
+    )
+    assert response.status_code == 200, response.text
+    doc_id = response.json()["id"]
+
+    response = client.get(f"/documents/{doc_id}", headers={"X-API-Key": "testkey"})
+    assert response.status_code == 200
+
+    preview = client.get(f"/documents/{doc_id}/preview", headers={"X-API-Key": "testkey"})
+    assert preview.status_code == 200
+    assert "preview" in preview.json()
+
+    delete = client.delete(f"/documents/{doc_id}", headers={"X-API-Key": "testkey"})
+    assert delete.status_code == 200
+
+    shutil.rmtree(tmpdir)


### PR DESCRIPTION
## Summary
- add FastAPI app with Document model for storing filename, path, customer, and task
- implement local/S3 storage helpers and secure upload/delete/preview endpoints
- add tests for document workflow

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement fastapi)
- `pytest` (fails: ModuleNotFoundError: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68c6a12f7124832f9e7967cab08de9ea