### PR TITLE
Add settings menu with DeepL translation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,46 @@
-- 👋 Hi, I’m @Chrismatthew244
-- 👀 I’m interested in OSINT
-- 🌱 I’m currently learning phyton
-- 💞️ I’m looking to collaborate on OSINT
-- 📫 How to reach me chrismatthew244@protonmail.com
+# Telegram Live Dashboard (Userbot)
 
-<!---
-Chrismatthew244/Chrismatthew244 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+A local web dashboard that monitors up to 4 Telegram channels in real time, translates messages to Danish, highlights keyword alerts, and keeps an alert history.
+
+## Features
+- **Live multi-channel feed** with 2–4 columns that auto-resize based on active slots.
+- **On-the-fly channel switching** by username or invite link.
+- **Danish translation** via `deep_translator` for every incoming message.
+- **Keyword alerting** with glowing red cards + audible notifications.
+- **Alert history** to review triggered keyword matches.
+
+## Requirements
+- Python 3.10+
+- A Telegram API ID + API HASH (from https://my.telegram.org)
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Environment Setup
+Create a `.env` file in the project root:
+
+```bash
+API_ID=123456
+API_HASH=your_api_hash_here
+# Optional: change the session file name
+SESSION_NAME=telegram_dashboard
+```
+
+## Run the App
+
+```bash
+uvicorn main:app --reload
+```
+
+Visit: `http://127.0.0.1:8000`
+
+## Translation Settings
+Open the settings menu (top-right gear icon) to:
+- Choose the translation provider (Google or DeepL).
+- Set the target translation language (default: Danish `da`).
+- Enter your DeepL API key and monitor usage if DeepL is selected.
+
+> **Note:** On first run, Telethon may prompt you to authenticate your Telegram account in the terminal. Complete the login to generate the session file.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,327 @@
+import asyncio
+import logging
+import os
+from typing import Dict, Optional, Set, Tuple
+
+import requests
+from deep_translator import DeeplTranslator, GoogleTranslator
+from dotenv import load_dotenv
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from starlette.requests import Request
+from telethon import TelegramClient, events
+
+load_dotenv()
+
+API_ID = os.getenv("API_ID")
+API_HASH = os.getenv("API_HASH")
+SESSION_NAME = os.getenv("SESSION_NAME", "telegram_dashboard")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("telegram_dashboard")
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+
+class WebSocketManager:
+    def __init__(self) -> None:
+        self.active_connections: Set[WebSocket] = set()
+        self.lock = asyncio.Lock()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self.lock:
+            self.active_connections.add(websocket)
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        async with self.lock:
+            self.active_connections.discard(websocket)
+
+    async def broadcast(self, message: dict) -> None:
+        async with self.lock:
+            connections = list(self.active_connections)
+        for connection in connections:
+            try:
+                await connection.send_json(message)
+            except RuntimeError:
+                await self.disconnect(connection)
+
+
+class DashboardState:
+    def __init__(self) -> None:
+        self.slot_to_chat_id: Dict[int, int] = {}
+        self.slot_to_title: Dict[int, str] = {}
+        self.chat_id_to_slot: Dict[int, int] = {}
+        self.keywords: Set[str] = set()
+        self.translation_provider = "google"
+        self.target_language = "da"
+        self.deepl_api_key: Optional[str] = None
+        self.deepl_usage: Optional[dict] = None
+        self.lock = asyncio.Lock()
+
+    async def set_keywords(self, keywords: Set[str]) -> None:
+        async with self.lock:
+            self.keywords = keywords
+
+    async def set_translation_settings(
+        self,
+        provider: str,
+        target_language: str,
+        deepl_api_key: Optional[str],
+        deepl_usage: Optional[dict],
+    ) -> None:
+        async with self.lock:
+            self.translation_provider = provider
+            self.target_language = target_language
+            if deepl_api_key is not None:
+                self.deepl_api_key = deepl_api_key
+            self.deepl_usage = deepl_usage
+
+    async def assign_slot(self, slot: int, chat_id: int, title: str) -> None:
+        async with self.lock:
+            previous_chat_id = self.slot_to_chat_id.get(slot)
+            if previous_chat_id:
+                self.chat_id_to_slot.pop(previous_chat_id, None)
+            self.slot_to_chat_id[slot] = chat_id
+            self.slot_to_title[slot] = title
+            self.chat_id_to_slot[chat_id] = slot
+
+    async def clear_slot(self, slot: int) -> None:
+        async with self.lock:
+            previous_chat_id = self.slot_to_chat_id.pop(slot, None)
+            if previous_chat_id:
+                self.chat_id_to_slot.pop(previous_chat_id, None)
+            self.slot_to_title.pop(slot, None)
+
+    async def get_slot_for_chat(self, chat_id: int) -> Optional[int]:
+        async with self.lock:
+            return self.chat_id_to_slot.get(chat_id)
+
+    async def get_state_snapshot(self) -> dict:
+        async with self.lock:
+            return {
+                "slots": {
+                    str(slot): {
+                        "chat_id": chat_id,
+                        "title": self.slot_to_title.get(slot),
+                    }
+                    for slot, chat_id in self.slot_to_chat_id.items()
+                },
+                "keywords": sorted(self.keywords),
+                "translation": {
+                    "provider": self.translation_provider,
+                    "target_language": self.target_language,
+                    "deepl_usage": self.deepl_usage,
+                },
+            }
+
+    async def find_keyword(self, text: str) -> Optional[str]:
+        async with self.lock:
+            keywords = list(self.keywords)
+        lowered = text.lower()
+        for keyword in keywords:
+            if keyword and keyword.lower() in lowered:
+                return keyword
+        return None
+
+    async def get_translation_settings(self) -> dict:
+        async with self.lock:
+            return {
+                "provider": self.translation_provider,
+                "target_language": self.target_language,
+                "deepl_api_key": self.deepl_api_key,
+            }
+
+
+manager = WebSocketManager()
+state = DashboardState()
+telegram_client: Optional[TelegramClient] = None
+translator_cache: Dict[Tuple[str, str, Optional[str]], object] = {}
+
+
+def get_translator(provider: str, target_language: str, api_key: Optional[str]) -> object:
+    cache_key = (provider, target_language, api_key)
+    if cache_key in translator_cache:
+        return translator_cache[cache_key]
+    if provider == "deepl" and api_key:
+        translator_instance = DeeplTranslator(
+            api_key=api_key,
+            source="auto",
+            target=target_language,
+        )
+    else:
+        translator_instance = GoogleTranslator(source="auto", target=target_language)
+    translator_cache[cache_key] = translator_instance
+    return translator_instance
+
+
+async def fetch_deepl_usage(api_key: str) -> Optional[dict]:
+    if not api_key:
+        return None
+    base_url = "https://api-free.deepl.com/v2/usage"
+    if not api_key.endswith(":fx"):
+        base_url = "https://api.deepl.com/v2/usage"
+
+    def _request_usage() -> dict:
+        response = requests.get(
+            base_url,
+            headers={"Authorization": f"DeepL-Auth-Key {api_key}"},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    try:
+        return await asyncio.to_thread(_request_usage)
+    except Exception as exc:
+        logger.warning("DeepL usage request failed: %s", exc)
+        return None
+
+
+async def translate_text(text: str) -> str:
+    if not text:
+        return ""
+    try:
+        settings = await state.get_translation_settings()
+        provider = settings["provider"]
+        target_language = settings["target_language"]
+        api_key = settings.get("deepl_api_key")
+        if provider == "deepl" and not api_key:
+            return text
+        translator_instance = get_translator(provider, target_language, api_key)
+        return await asyncio.to_thread(translator_instance.translate, text)
+    except Exception as exc:
+        logger.warning("Translation failed: %s", exc)
+        return text
+
+
+async def resolve_channel(identifier: str) -> dict:
+    if telegram_client is None:
+        raise RuntimeError("Telegram client not initialized")
+    entity = await telegram_client.get_entity(identifier)
+    title = getattr(entity, "title", None) or getattr(entity, "username", None) or str(entity)
+    chat_id = entity.id
+    return {"title": title, "chat_id": chat_id}
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    global telegram_client
+    if not API_ID or not API_HASH:
+        logger.warning("API_ID or API_HASH missing; Telegram client will not start.")
+        return
+    telegram_client = TelegramClient(SESSION_NAME, int(API_ID), API_HASH)
+    await telegram_client.start()
+
+    @telegram_client.on(events.NewMessage)
+    async def handle_new_message(event: events.NewMessage.Event) -> None:
+        if event.chat_id is None:
+            return
+        slot = await state.get_slot_for_chat(event.chat_id)
+        if slot is None:
+            return
+        original_text = event.message.message or ""
+        translated_text = await translate_text(original_text)
+        sender = "Unknown"
+        if event.chat is not None:
+            sender = getattr(event.chat, "title", None) or getattr(event.chat, "username", None) or "Unknown"
+        timestamp = event.message.date.isoformat()
+        keyword = await state.find_keyword(f"{original_text} {translated_text}")
+        is_alert = keyword is not None
+        await manager.broadcast(
+            {
+                "type": "message",
+                "slot": slot,
+                "timestamp": timestamp,
+                "sender": sender,
+                "translated_text": translated_text,
+                "original_text": original_text,
+                "is_alert": is_alert,
+                "keyword": keyword,
+            }
+        )
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    if telegram_client is not None:
+        await telegram_client.disconnect()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await manager.connect(websocket)
+    try:
+        await websocket.send_json({"type": "init", **(await state.get_state_snapshot())})
+        while True:
+            data = await websocket.receive_json()
+            message_type = data.get("type")
+            if message_type == "set_keywords":
+                keywords = {
+                    keyword.strip()
+                    for keyword in data.get("keywords", [])
+                    if keyword and keyword.strip()
+                }
+                await state.set_keywords(keywords)
+                await manager.broadcast({"type": "keywords", "keywords": sorted(keywords)})
+            elif message_type == "set_translation":
+                provider = (data.get("provider") or "google").lower()
+                target_language = (data.get("target_language") or "da").lower()
+                deepl_api_key = data.get("deepl_api_key")
+                deepl_usage = None
+                if provider == "deepl" and deepl_api_key:
+                    deepl_usage = await fetch_deepl_usage(deepl_api_key)
+                await state.set_translation_settings(
+                    provider=provider,
+                    target_language=target_language,
+                    deepl_api_key=deepl_api_key,
+                    deepl_usage=deepl_usage,
+                )
+                await manager.broadcast(
+                    {
+                        "type": "translation_settings",
+                        "provider": provider,
+                        "target_language": target_language,
+                        "deepl_usage": deepl_usage,
+                    }
+                )
+            elif message_type == "load_channel":
+                slot = int(data.get("slot"))
+                identifier = (data.get("identifier") or "").strip()
+                if not identifier:
+                    await state.clear_slot(slot)
+                    await manager.broadcast({"type": "slot_cleared", "slot": slot})
+                    continue
+                try:
+                    channel_info = await resolve_channel(identifier)
+                    await state.assign_slot(slot, channel_info["chat_id"], channel_info["title"])
+                    await manager.broadcast(
+                        {
+                            "type": "slot_loaded",
+                            "slot": slot,
+                            "title": channel_info["title"],
+                            "identifier": identifier,
+                        }
+                    )
+                except Exception as exc:
+                    await websocket.send_json(
+                        {
+                            "type": "error",
+                            "message": f"Failed to load channel: {exc}",
+                            "slot": slot,
+                        }
+                    )
+            else:
+                await websocket.send_json({"type": "error", "message": "Unknown command"})
+    except WebSocketDisconnect:
+        await manager.disconnect(websocket)
+    except Exception as exc:
+        logger.error("WebSocket error: %s", exc)
+        await manager.disconnect(websocket)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+telethon
+deep-translator
+python-dotenv
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,581 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Telegram Live Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-slate-900 text-slate-100">
+    <div class="mx-auto flex min-h-screen max-w-7xl flex-col gap-4 px-4 py-6">
+      <header class="flex flex-col gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 class="text-2xl font-semibold text-cyan-300">Telegram Live Dashboard</h1>
+          <p class="text-sm text-slate-400">Monitor up to 4 channels with real-time translation & alerts.</p>
+        </div>
+        <div class="flex flex-1 flex-col gap-3 md:flex-row md:items-center md:justify-end">
+          <div class="flex w-full max-w-xl items-center gap-2">
+            <label for="keywordInput" class="text-sm text-slate-300">Keywords</label>
+            <input
+              id="keywordInput"
+              type="text"
+              placeholder="breaking, alert, urgent"
+              class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-cyan-400 focus:outline-none"
+            />
+            <button
+              id="keywordButton"
+              class="rounded-lg bg-cyan-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow-lg shadow-cyan-500/20 transition hover:bg-cyan-400"
+            >
+              Apply
+            </button>
+          </div>
+          <button
+            id="audioToggle"
+            class="rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-semibold text-slate-200 shadow-lg shadow-purple-500/10 transition hover:border-cyan-400"
+          >
+            🔊 Audio On
+          </button>
+          <button
+            id="settingsToggle"
+            class="rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-semibold text-slate-200 shadow-lg shadow-purple-500/10 transition hover:border-cyan-400"
+          >
+            ⚙️ Settings
+          </button>
+        </div>
+      </header>
+
+      <section
+        id="settingsPanel"
+        class="hidden rounded-2xl border border-slate-800 bg-slate-950/80 p-4 shadow-lg shadow-cyan-500/10"
+      >
+        <div class="flex flex-col gap-6 lg:flex-row">
+          <div class="flex-1 space-y-4">
+            <div class="flex items-center justify-between">
+              <h2 class="text-lg font-semibold text-cyan-300">Channel Configuration</h2>
+              <span class="text-xs text-slate-400">Load channels into slots 1-4</span>
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+                <p class="text-xs font-semibold text-slate-300">Slot 1</p>
+                <div class="mt-2 flex items-center gap-2">
+                  <input
+                    type="text"
+                    placeholder="@breakingnews"
+                    class="settings-slot-input w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100 focus:border-cyan-400 focus:outline-none"
+                    data-settings-slot-input="1"
+                  />
+                  <button
+                    class="settings-slot-load rounded-lg bg-cyan-500 px-3 py-2 text-xs font-semibold text-slate-900 hover:bg-cyan-400"
+                    data-settings-slot-button="1"
+                  >
+                    Load
+                  </button>
+                </div>
+              </div>
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+                <p class="text-xs font-semibold text-slate-300">Slot 2</p>
+                <div class="mt-2 flex items-center gap-2">
+                  <input
+                    type="text"
+                    placeholder="@tech"
+                    class="settings-slot-input w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100 focus:border-cyan-400 focus:outline-none"
+                    data-settings-slot-input="2"
+                  />
+                  <button
+                    class="settings-slot-load rounded-lg bg-cyan-500 px-3 py-2 text-xs font-semibold text-slate-900 hover:bg-cyan-400"
+                    data-settings-slot-button="2"
+                  >
+                    Load
+                  </button>
+                </div>
+              </div>
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+                <p class="text-xs font-semibold text-slate-300">Slot 3</p>
+                <div class="mt-2 flex items-center gap-2">
+                  <input
+                    type="text"
+                    placeholder="@markets"
+                    class="settings-slot-input w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100 focus:border-cyan-400 focus:outline-none"
+                    data-settings-slot-input="3"
+                  />
+                  <button
+                    class="settings-slot-load rounded-lg bg-cyan-500 px-3 py-2 text-xs font-semibold text-slate-900 hover:bg-cyan-400"
+                    data-settings-slot-button="3"
+                  >
+                    Load
+                  </button>
+                </div>
+              </div>
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+                <p class="text-xs font-semibold text-slate-300">Slot 4</p>
+                <div class="mt-2 flex items-center gap-2">
+                  <input
+                    type="text"
+                    placeholder="@alerts"
+                    class="settings-slot-input w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100 focus:border-cyan-400 focus:outline-none"
+                    data-settings-slot-input="4"
+                  />
+                  <button
+                    class="settings-slot-load rounded-lg bg-cyan-500 px-3 py-2 text-xs font-semibold text-slate-900 hover:bg-cyan-400"
+                    data-settings-slot-button="4"
+                  >
+                    Load
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex-1 space-y-4">
+            <div class="flex items-center justify-between">
+              <h2 class="text-lg font-semibold text-purple-300">Translation Settings</h2>
+              <span class="text-xs text-slate-400">Choose provider & language</span>
+            </div>
+            <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4 space-y-4">
+              <div class="grid gap-3 md:grid-cols-2">
+                <label class="text-xs text-slate-300">
+                  Provider
+                  <select
+                    id="translationProvider"
+                    class="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100 focus:border-cyan-400 focus:outline-none"
+                  >
+                    <option value="google">Google</option>
+                    <option value="deepl">DeepL</option>
+                  </select>
+                </label>
+                <label class="text-xs text-slate-300">
+                  Target Language
+                  <select
+                    id="targetLanguage"
+                    class="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100 focus:border-cyan-400 focus:outline-none"
+                  >
+                    <option value="da">Danish (da)</option>
+                    <option value="en">English (en)</option>
+                    <option value="de">German (de)</option>
+                    <option value="fr">French (fr)</option>
+                    <option value="es">Spanish (es)</option>
+                    <option value="it">Italian (it)</option>
+                    <option value="nl">Dutch (nl)</option>
+                    <option value="sv">Swedish (sv)</option>
+                    <option value="no">Norwegian (no)</option>
+                  </select>
+                </label>
+              </div>
+              <div id="deeplSettings" class="space-y-3 hidden">
+                <label class="text-xs text-slate-300">
+                  DeepL API Key
+                  <input
+                    id="deeplApiKey"
+                    type="password"
+                    placeholder="Enter DeepL API key"
+                    class="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100 focus:border-cyan-400 focus:outline-none"
+                  />
+                </label>
+                <div class="space-y-2">
+                  <div class="flex items-center justify-between text-xs text-slate-300">
+                    <span>DeepL Usage</span>
+                    <span id="deeplUsageLabel">No data</span>
+                  </div>
+                  <div class="h-2 w-full rounded-full bg-slate-800">
+                    <div id="deeplUsageBar" class="h-2 rounded-full bg-slate-600" style="width: 0%;"></div>
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center justify-end gap-2">
+                <button
+                  id="translationApply"
+                  class="rounded-lg bg-purple-500 px-4 py-2 text-xs font-semibold text-slate-900 hover:bg-purple-400"
+                >
+                  Apply Translation Settings
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-purple-500/10">
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-purple-300">Alert History</h2>
+          <span class="text-xs text-slate-400">Captured keyword hits</span>
+        </div>
+        <div id="alertHistory" class="mt-3 max-h-40 space-y-2 overflow-y-auto pr-2">
+          <p class="text-sm text-slate-500">No alerts yet. Waiting for keyword hits...</p>
+        </div>
+      </section>
+
+      <main id="columns" class="grid gap-4" style="grid-template-columns: repeat(1, minmax(0, 1fr));">
+        <div class="channel-column hidden flex-col gap-3" data-slot="1">
+          <div class="rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10">
+            <div class="flex flex-col gap-3">
+              <div class="flex items-center justify-between">
+                <h3 class="text-base font-semibold text-cyan-300" data-slot-title="1">Slot 1</h3>
+                <span class="text-xs text-slate-500" data-slot-status="1">Idle</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <input
+                  type="text"
+                  placeholder="Enter Channel/Group Link"
+                  class="slot-input w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-cyan-400 focus:outline-none"
+                  data-slot-input="1"
+                />
+                <button
+                  class="slot-load rounded-lg bg-cyan-500 px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-cyan-400"
+                  data-slot-button="1"
+                >
+                  Load
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="message-feed flex flex-1 flex-col gap-3 overflow-y-auto rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10" data-slot-feed="1">
+            <p class="text-sm text-slate-500">Load a channel to begin streaming messages.</p>
+          </div>
+        </div>
+
+        <div class="channel-column hidden flex-col gap-3" data-slot="2">
+          <div class="rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10">
+            <div class="flex flex-col gap-3">
+              <div class="flex items-center justify-between">
+                <h3 class="text-base font-semibold text-cyan-300" data-slot-title="2">Slot 2</h3>
+                <span class="text-xs text-slate-500" data-slot-status="2">Idle</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <input
+                  type="text"
+                  placeholder="Enter Channel/Group Link"
+                  class="slot-input w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-cyan-400 focus:outline-none"
+                  data-slot-input="2"
+                />
+                <button
+                  class="slot-load rounded-lg bg-cyan-500 px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-cyan-400"
+                  data-slot-button="2"
+                >
+                  Load
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="message-feed flex flex-1 flex-col gap-3 overflow-y-auto rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10" data-slot-feed="2">
+            <p class="text-sm text-slate-500">Load a channel to begin streaming messages.</p>
+          </div>
+        </div>
+
+        <div class="channel-column hidden flex-col gap-3" data-slot="3">
+          <div class="rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10">
+            <div class="flex flex-col gap-3">
+              <div class="flex items-center justify-between">
+                <h3 class="text-base font-semibold text-cyan-300" data-slot-title="3">Slot 3</h3>
+                <span class="text-xs text-slate-500" data-slot-status="3">Idle</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <input
+                  type="text"
+                  placeholder="Enter Channel/Group Link"
+                  class="slot-input w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-cyan-400 focus:outline-none"
+                  data-slot-input="3"
+                />
+                <button
+                  class="slot-load rounded-lg bg-cyan-500 px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-cyan-400"
+                  data-slot-button="3"
+                >
+                  Load
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="message-feed flex flex-1 flex-col gap-3 overflow-y-auto rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10" data-slot-feed="3">
+            <p class="text-sm text-slate-500">Load a channel to begin streaming messages.</p>
+          </div>
+        </div>
+
+        <div class="channel-column hidden flex-col gap-3" data-slot="4">
+          <div class="rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10">
+            <div class="flex flex-col gap-3">
+              <div class="flex items-center justify-between">
+                <h3 class="text-base font-semibold text-cyan-300" data-slot-title="4">Slot 4</h3>
+                <span class="text-xs text-slate-500" data-slot-status="4">Idle</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <input
+                  type="text"
+                  placeholder="Enter Channel/Group Link"
+                  class="slot-input w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-cyan-400 focus:outline-none"
+                  data-slot-input="4"
+                />
+                <button
+                  class="slot-load rounded-lg bg-cyan-500 px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-cyan-400"
+                  data-slot-button="4"
+                >
+                  Load
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="message-feed flex flex-1 flex-col gap-3 overflow-y-auto rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-cyan-500/10" data-slot-feed="4">
+            <p class="text-sm text-slate-500">Load a channel to begin streaming messages.</p>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <script>
+      const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
+      const socket = new WebSocket(`${wsProtocol}://${window.location.host}/ws`);
+
+      const columnsContainer = document.getElementById("columns");
+      const alertHistory = document.getElementById("alertHistory");
+      const keywordInput = document.getElementById("keywordInput");
+      const keywordButton = document.getElementById("keywordButton");
+      const audioToggle = document.getElementById("audioToggle");
+      const settingsToggle = document.getElementById("settingsToggle");
+      const settingsPanel = document.getElementById("settingsPanel");
+      const translationProvider = document.getElementById("translationProvider");
+      const targetLanguage = document.getElementById("targetLanguage");
+      const deeplApiKey = document.getElementById("deeplApiKey");
+      const deeplSettings = document.getElementById("deeplSettings");
+      const deeplUsageLabel = document.getElementById("deeplUsageLabel");
+      const deeplUsageBar = document.getElementById("deeplUsageBar");
+      const translationApply = document.getElementById("translationApply");
+
+      const activeSlots = new Set();
+      let audioEnabled = true;
+
+      const slotElements = Array.from(document.querySelectorAll(".channel-column")).reduce(
+        (acc, element) => {
+          const slot = element.dataset.slot;
+          acc[slot] = element;
+          return acc;
+        },
+        {}
+      );
+
+      function updateLayout() {
+        const count = activeSlots.size || 1;
+        columnsContainer.style.gridTemplateColumns = `repeat(${count}, minmax(0, 1fr))`;
+        Object.entries(slotElements).forEach(([slot, element]) => {
+          if (activeSlots.has(parseInt(slot, 10))) {
+            element.classList.remove("hidden");
+          } else {
+            element.classList.add("hidden");
+          }
+        });
+      }
+
+      function updateDeepLVisibility() {
+        const isDeepL = translationProvider.value === "deepl";
+        deeplSettings.classList.toggle("hidden", !isDeepL);
+      }
+
+      function updateDeepLUsage(usage) {
+        if (!usage || !usage.character_limit) {
+          deeplUsageLabel.textContent = "No data";
+          deeplUsageBar.style.width = "0%";
+          deeplUsageBar.classList.remove("bg-red-500");
+          deeplUsageBar.classList.add("bg-slate-600");
+          return;
+        }
+        const percent = Math.min((usage.character_count / usage.character_limit) * 100, 100);
+        deeplUsageLabel.textContent = `${usage.character_count} / ${usage.character_limit}`;
+        deeplUsageBar.style.width = `${percent}%`;
+        deeplUsageBar.classList.remove("bg-slate-600");
+        deeplUsageBar.classList.add("bg-red-500");
+      }
+
+      function sendLoadChannel(slot, identifier) {
+        socket.send(
+          JSON.stringify({
+            type: "load_channel",
+            slot,
+            identifier,
+          })
+        );
+      }
+
+      function playBeep() {
+        if (!audioEnabled) return;
+        const context = new (window.AudioContext || window.webkitAudioContext)();
+        const oscillator = context.createOscillator();
+        const gainNode = context.createGain();
+        oscillator.type = "square";
+        oscillator.frequency.value = 880;
+        gainNode.gain.value = 0.15;
+        oscillator.connect(gainNode);
+        gainNode.connect(context.destination);
+        oscillator.start();
+        setTimeout(() => {
+          oscillator.stop();
+          context.close();
+        }, 150);
+      }
+
+      function createMessageCard(data) {
+        const card = document.createElement("div");
+        card.className =
+          "rounded-xl border border-slate-800 bg-slate-900/80 p-3 shadow-lg shadow-cyan-500/10";
+        if (data.is_alert) {
+          card.classList.add("border-red-500", "shadow-red-500/40", "shadow-2xl");
+        }
+        card.innerHTML = `
+          <div class="flex items-center justify-between text-xs text-slate-400">
+            <span>${new Date(data.timestamp).toLocaleTimeString()}</span>
+            <span>${data.sender}</span>
+          </div>
+          <p class="mt-2 text-sm font-semibold text-white">${data.translated_text || ""}</p>
+          <p class="mt-1 text-xs text-slate-400">${data.original_text || ""}</p>
+        `;
+        return card;
+      }
+
+      function addAlertHistory(data) {
+        if (!alertHistory) return;
+        const empty = alertHistory.querySelector("p");
+        if (empty) {
+          empty.remove();
+        }
+        const entry = document.createElement("div");
+        entry.className = "rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-200";
+        entry.textContent = `${new Date(data.timestamp).toLocaleTimeString()} • ${data.sender} • Keyword: ${
+          data.keyword || "Matched"
+        }`;
+        alertHistory.prepend(entry);
+      }
+
+      socket.addEventListener("message", (event) => {
+        const data = JSON.parse(event.data);
+        if (data.type === "init") {
+          keywordInput.value = (data.keywords || []).join(", ");
+          if (data.translation) {
+            translationProvider.value = data.translation.provider || "google";
+            targetLanguage.value = data.translation.target_language || "da";
+            updateDeepLUsage(data.translation.deepl_usage);
+            updateDeepLVisibility();
+          }
+          Object.entries(data.slots || {}).forEach(([slot, slotData]) => {
+            const slotNumber = parseInt(slot, 10);
+            if (slotData && slotData.title) {
+              activeSlots.add(slotNumber);
+              document.querySelector(`[data-slot-title="${slot}"]`).textContent = slotData.title;
+              document.querySelector(`[data-slot-status="${slot}"]`).textContent = "Live";
+            }
+          });
+          updateLayout();
+          return;
+        }
+
+        if (data.type === "slot_loaded") {
+          activeSlots.add(data.slot);
+          document.querySelector(`[data-slot-title="${data.slot}"]`).textContent = data.title;
+          document.querySelector(`[data-slot-status="${data.slot}"]`).textContent = "Live";
+          const feed = document.querySelector(`[data-slot-feed="${data.slot}"]`);
+          if (feed) {
+            feed.innerHTML = "";
+          }
+          updateLayout();
+          return;
+        }
+
+        if (data.type === "slot_cleared") {
+          activeSlots.delete(data.slot);
+          const feed = document.querySelector(`[data-slot-feed="${data.slot}"]`);
+          if (feed) {
+            feed.innerHTML = '<p class="text-sm text-slate-500">Load a channel to begin streaming messages.</p>';
+          }
+          document.querySelector(`[data-slot-title="${data.slot}"]`).textContent = `Slot ${data.slot}`;
+          document.querySelector(`[data-slot-status="${data.slot}"]`).textContent = "Idle";
+          updateLayout();
+          return;
+        }
+
+        if (data.type === "keywords") {
+          keywordInput.value = (data.keywords || []).join(", ");
+          return;
+        }
+
+        if (data.type === "translation_settings") {
+          translationProvider.value = data.provider || "google";
+          targetLanguage.value = data.target_language || "da";
+          updateDeepLUsage(data.deepl_usage);
+          updateDeepLVisibility();
+          return;
+        }
+
+        if (data.type === "message") {
+          const feed = document.querySelector(`[data-slot-feed="${data.slot}"]`);
+          if (!feed) return;
+          if (!activeSlots.has(data.slot)) {
+            activeSlots.add(data.slot);
+            updateLayout();
+          }
+          feed.prepend(createMessageCard(data));
+          if (data.is_alert) {
+            playBeep();
+            addAlertHistory(data);
+          }
+          return;
+        }
+
+        if (data.type === "error") {
+          alert(data.message || "An error occurred.");
+        }
+      });
+
+      document.querySelectorAll(".slot-load").forEach((button) => {
+        button.addEventListener("click", () => {
+          const slot = parseInt(button.dataset.slotButton, 10);
+          const input = document.querySelector(`[data-slot-input="${slot}"]`);
+          sendLoadChannel(slot, input.value.trim());
+        });
+      });
+
+      document.querySelectorAll(".settings-slot-load").forEach((button) => {
+        button.addEventListener("click", () => {
+          const slot = parseInt(button.dataset.settingsSlotButton, 10);
+          const input = document.querySelector(`[data-settings-slot-input="${slot}"]`);
+          sendLoadChannel(slot, input.value.trim());
+        });
+      });
+
+      keywordButton.addEventListener("click", () => {
+        const keywords = keywordInput.value
+          .split(",")
+          .map((keyword) => keyword.trim())
+          .filter(Boolean);
+        socket.send(JSON.stringify({ type: "set_keywords", keywords }));
+      });
+
+      keywordInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+          keywordButton.click();
+        }
+      });
+
+      translationApply.addEventListener("click", () => {
+        socket.send(
+          JSON.stringify({
+            type: "set_translation",
+            provider: translationProvider.value,
+            target_language: targetLanguage.value,
+            deepl_api_key: deeplApiKey.value.trim(),
+          })
+        );
+      });
+
+      translationProvider.addEventListener("change", updateDeepLVisibility);
+
+      audioToggle.addEventListener("click", () => {
+        audioEnabled = !audioEnabled;
+        audioToggle.textContent = audioEnabled ? "🔊 Audio On" : "🔇 Audio Off";
+        audioToggle.classList.toggle("border-cyan-400", audioEnabled);
+        audioToggle.classList.toggle("text-cyan-200", audioEnabled);
+      });
+
+      settingsToggle.addEventListener("click", () => {
+        settingsPanel.classList.toggle("hidden");
+      });
+
+      updateLayout();
+      updateDeepLVisibility();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a top-right settings menu to configure which Telegram channels are monitored and to control translation provider/language and DeepL credentials and usage visibility.
- Allow users to choose DeepL for higher-quality translations and to see account usage when DeepL is selected.

### Description
- Add `main.py` backend state and WebSocket handling for translation settings, including `translation_provider`, `target_language`, `deepl_api_key`, `deepl_usage`, `get_translator` helper, and `fetch_deepl_usage` (DeepL usage lookup via `requests`).
- Extend the WebSocket command set to accept `set_translation` messages and broadcast `translation_settings` updates to clients while preserving existing channel loading and message streaming logic.
- Add `templates/index.html` UI for a settings panel with channel slot configuration, translation provider/language selectors, DeepL API key input, usage bar, settings toggle button, and client JS to send `set_translation` and manage visibility and usage display.
- Update `requirements.txt` to include `requests` and update `README.md` with the new translation settings usage instructions.

### Testing
- Ran a headless browser smoke test with Playwright that opened the dashboard HTML and toggled the settings panel to capture a screenshot, which completed successfully.
- Started a simple static HTTP server to serve the UI for the smoke test, which ran successfully for the test duration.
- No unit tests or automated integration tests exercising the WebSocket/Telegram message flow or DeepL API calls were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971556b1b58832f82bdc552927ca2d5)